### PR TITLE
Adjustments to MarketValue of commodities

### DIFF
--- a/1.1/Defs/ThingDefs_Items/Items_Resource_RawPlant.xml
+++ b/1.1/Defs/ThingDefs_Items/Items_Resource_RawPlant.xml
@@ -10,7 +10,7 @@
 			<texPath>Things/Items/Raw/VBE_CoffeeBeans</texPath>
 		</graphicData>
 		<statBases>
-			<MarketValue>1.9</MarketValue>
+			<MarketValue>0.9</MarketValue>
 			<Flammability>1.3</Flammability>
 		</statBases>
 		<comps>
@@ -35,7 +35,7 @@
 			<texPath>Things/Items/Raw/VBE_TeaLeaves</texPath>
 		</graphicData>
 		<statBases>
-			<MarketValue>1.9</MarketValue>
+			<MarketValue>0.85</MarketValue>
 			<Flammability>1.3</Flammability>
 		</statBases>
 		<comps>
@@ -60,7 +60,7 @@
 			<texPath>Things/Items/Raw/VBE_TobaccoLeaves</texPath>
 		</graphicData>
 		<statBases>
-			<MarketValue>1.9</MarketValue>
+			<MarketValue>1.5</MarketValue>
 			<Flammability>1.3</Flammability>
 		</statBases>
 		<comps>

--- a/1.1/Defs/ThingDefs_Items/Items_Smokes.xml
+++ b/1.1/Defs/ThingDefs_Items/Items_Smokes.xml
@@ -15,7 +15,7 @@
 		<rotatable>false</rotatable>
 		<statBases>
 			<WorkToMake>450</WorkToMake>
-			<MarketValue>8</MarketValue>
+			<MarketValue>12</MarketValue>
 			<Mass>0.05</Mass>
 			<DeteriorationRate>6</DeteriorationRate>
 			<Flammability>1.3</Flammability>

--- a/1.2/Defs/ThingDefs_Items/Items_Resource_RawPlant.xml
+++ b/1.2/Defs/ThingDefs_Items/Items_Resource_RawPlant.xml
@@ -10,7 +10,7 @@
 			<texPath>Things/Items/Raw/VBE_CoffeeBeans</texPath>
 		</graphicData>
 		<statBases>
-			<MarketValue>1.9</MarketValue>
+			<MarketValue>0.9</MarketValue>
 			<Flammability>1.3</Flammability>
 		</statBases>
 		<comps>
@@ -35,7 +35,7 @@
 			<texPath>Things/Items/Raw/VBE_TeaLeaves</texPath>
 		</graphicData>
 		<statBases>
-			<MarketValue>1.9</MarketValue>
+			<MarketValue>0.85</MarketValue>
 			<Flammability>1.3</Flammability>
 		</statBases>
 		<comps>
@@ -60,7 +60,7 @@
 			<texPath>Things/Items/Raw/VBE_TobaccoLeaves</texPath>
 		</graphicData>
 		<statBases>
-			<MarketValue>1.9</MarketValue>
+			<MarketValue>1.5</MarketValue>
 			<Flammability>1.3</Flammability>
 		</statBases>
 		<comps>

--- a/1.2/Defs/ThingDefs_Items/Items_Smokes.xml
+++ b/1.2/Defs/ThingDefs_Items/Items_Smokes.xml
@@ -15,7 +15,7 @@
 		<rotatable>false</rotatable>
 		<statBases>
 			<WorkToMake>450</WorkToMake>
-			<MarketValue>8</MarketValue>
+			<MarketValue>12</MarketValue>
 			<Mass>0.05</Mass>
 			<DeteriorationRate>6</DeteriorationRate>
 			<Flammability>1.3</Flammability>

--- a/1.3/Defs/ThingDefs_Items/Items_Resource_RawPlant.xml
+++ b/1.3/Defs/ThingDefs_Items/Items_Resource_RawPlant.xml
@@ -10,7 +10,7 @@
 			<texPath>Things/Items/Raw/VBE_CoffeeBeans</texPath>
 		</graphicData>
 		<statBases>
-			<MarketValue>1.9</MarketValue>
+			<MarketValue>0.9</MarketValue>
 			<Flammability>1.3</Flammability>
 		</statBases>
 		<comps>
@@ -35,7 +35,7 @@
 			<texPath>Things/Items/Raw/VBE_TeaLeaves</texPath>
 		</graphicData>
 		<statBases>
-			<MarketValue>1.9</MarketValue>
+			<MarketValue>0.85</MarketValue>
 			<Flammability>1.3</Flammability>
 		</statBases>
 		<comps>
@@ -60,7 +60,7 @@
 			<texPath>Things/Items/Raw/VBE_TobaccoLeaves</texPath>
 		</graphicData>
 		<statBases>
-			<MarketValue>1.9</MarketValue>
+			<MarketValue>1.5</MarketValue>
 			<Flammability>1.3</Flammability>
 		</statBases>
 		<comps>

--- a/1.3/Defs/ThingDefs_Items/Items_Smokes.xml
+++ b/1.3/Defs/ThingDefs_Items/Items_Smokes.xml
@@ -15,7 +15,7 @@
 		<rotatable>false</rotatable>
 		<statBases>
 			<WorkToMake>450</WorkToMake>
-			<MarketValue>8</MarketValue>
+			<MarketValue>12</MarketValue>
 			<Mass>0.05</Mass>
 			<DeteriorationRate>6</DeteriorationRate>
 			<Flammability>1.3</Flammability>


### PR DESCRIPTION
Selling raw coffee beans, tea leaves or tobacco leaves shouldn't be more profitable than selling flake. 

Making coffee, tea or cigarettes from their raw ingredients should increase their value rather than reducing it.

Comparing profit per day (ppd), alongside grow time gives a good metric for the strength of a particular crop.

This PR introduces the following changes:

1. reduce the MarketValue of VBE_RawCoffee to 0.9, this brings the ppd down from 3.9 to 1.875 (compared to 1.68 for psychoid leaves profit) and means that producing coffee from beans increases the value rather than reducing it, with full process ppd (excluding work) being 3.33 (compared to flakes being 3.11).
2.  reduce the MarketValue of VBE_RawTea to 0.85, this brings the ppd down from 3.8 to 1.7. This also means that turning tea leaves into tea increases value, with full process ppd (excluding work) being 3.2.
3. reduce the MarketValue of VBE_RawTobacco to 1.5, this brings the ppd down from 2.23 to 1.76
4. increase the MarketValue of VBE_Cigarette to 12, this brings the ppd up from 1.88 to 2.82
