### PR TITLE
energy drinks no longer error when pawns have no `rest` need.

### DIFF
--- a/1.3/Source/VanillaBrewingExpanded/VanillaBrewingExpanded/Hediffs/Hediff_EnergyDrink.cs
+++ b/1.3/Source/VanillaBrewingExpanded/VanillaBrewingExpanded/Hediffs/Hediff_EnergyDrink.cs
@@ -25,7 +25,7 @@ namespace VanillaBrewingExpanded
         public override void PostAdd(DamageInfo? dinfo)
         {
             base.PostAdd(dinfo);
-            this.pawn.needs.rest.CurLevel += 0.2f;
+            this.pawn.needs.rest?.CurLevel += 0.2f;
         }
     }
 }

--- a/1.3/Source/VanillaBrewingExpanded/VanillaBrewingExpanded/Hediffs/Hediff_EnergyDrinkHangover.cs
+++ b/1.3/Source/VanillaBrewingExpanded/VanillaBrewingExpanded/Hediffs/Hediff_EnergyDrinkHangover.cs
@@ -10,7 +10,7 @@ namespace VanillaBrewingExpanded
         public override void PostAdd(DamageInfo? dinfo)
         {
             base.PostAdd(dinfo);
-            this.pawn.needs.rest.CurLevel -= 0.2f;
+            this.pawn.needs.rest?.CurLevel -= 0.2f;
         }
     }
 }


### PR DESCRIPTION
the drinks, they do nothing, but as the joke goes, if it hurts to have your "no rest need" pawns drinking energy drinks, stop telling them to do it.